### PR TITLE
v11.2: Forced the inclusion of record parameter on create requests

### DIFF
--- a/impl/src/java/org/sakaiproject/bbb/impl/bbbapi/BaseBBBAPI.java
+++ b/impl/src/java/org/sakaiproject/bbb/impl/bbbapi/BaseBBBAPI.java
@@ -169,9 +169,7 @@ public class BaseBBBAPI implements BBBAPI {
 
             // BSN: Parameters required for playback recording
             boolean recording = ( recordingenabled && meeting.getRecording() != null && meeting.getRecording().booleanValue() );
-            if ( recording ) {
-                query.append("&record=true");
-            }
+            query.append("&record=" + Boolean.toString(recording));
             query.append("&duration=");
             String duration = meeting.getRecordingDuration() != null? meeting.getRecordingDuration().toString(): "0";
             query.append(duration);


### PR DESCRIPTION
Some versions of BBB require the record parameter to be included, even if is set to false