### PR TITLE
Fixed recursive reload bug in bbb-autoclose

### DIFF
--- a/bundle/src/resources/ToolMessages.properties
+++ b/bundle/src/resources/ToolMessages.properties
@@ -240,3 +240,11 @@ bbb_err_meeting_description_too_long = The meeting description must be {0} chara
 #####################################
 bbb_message_recording = This session may be recorded
 bbb_message_meetingduration = The maximum duration for this session is {0} minutes
+
+
+#####################################
+# Autoclose
+#####################################
+bbb_autoclose1 = You left the meeting.
+bbb_autoclose2 = Your Browser does not support automatic closing of this Window.
+bbb_autoclose3 = Please close it manually!

--- a/impl/src/java/org/sakaiproject/bbb/impl/bbbapi/BaseBBBAPI.java
+++ b/impl/src/java/org/sakaiproject/bbb/impl/bbbapi/BaseBBBAPI.java
@@ -166,7 +166,7 @@ public class BaseBBBAPI implements BBBAPI {
                 query.append("&logoutURL=");
                 StringBuilder logoutUrl = new StringBuilder(config.getServerUrl());
                 logoutUrl.append(BBBMeetingManager.TOOL_WEBAPP);
-                logoutUrl.append("/bbb-autoclose.html");
+                logoutUrl.append("/bbb-autoclose.jsp");
                 query.append(URLEncoder.encode(logoutUrl.toString(), getParametersEncoding()));
             }
 

--- a/tool/src/webapp/bbb-autoclose.jsp
+++ b/tool/src/webapp/bbb-autoclose.jsp
@@ -1,5 +1,5 @@
-<!--
-
+<%@ page import="org.sakaiproject.util.ResourceLoader" %>
+<%--
     Copyright (c) 2010 onwards - The Sakai Foundation
 
     Licensed under the Educational Community License, Version 2.0 (the "License");
@@ -14,29 +14,32 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 
--->
+--%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
 <html
         xmlns="http://www.w3.org/1999/xhtml"
         xml:lang="en"
         lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <script type="text/javascript" language="JavaScript" src="/bbb-tool/lib/jquery-1.3.2.min.js"></script>
     <script type="text/javascript" language="JavaScript">
         function closeWindow() {
-            var objWindow = window.open('', '_self', '');
+            var objWindow = window.open('', "_self", '');
             objWindow.close();
         }
     </script>
 </head>
 <body onload="closeWindow()" style="width:99.5%">
 <span style="margin:50px auto">
-<h2>You left the meeting.</h2>
-<h3>Your Browser does not support automatic closing of this Window.</h3>
-<h2>Please close it manually!</h2>
-    </span>
+<%! ResourceLoader rl = new ResourceLoader("ToolMessages"); %>
+<% rl.setContextLocale(request.getLocale()); %>
+<%= "<h2>" + rl.getString("bbb_autoclose1") + "</h2>" %>
+<%= "<h3>" + rl.getString("bbb_autoclose2") + "</h3>" %>
+<%= "<h2>" + rl.getString("bbb_autoclose3") + "</h2>" %>
+</>
 </body>
 </html>


### PR DESCRIPTION
**added bbb-autoclose.jsp with localized message** (did not find another solution than plain java in jsp file. Because this is a static resource, nothing else works. Because it does not live inside the sakai-session, you do not get the sakai-locale (instead of default en_US) -> thats why the browser locale is used.)
**changed bbb-autoclose html to do not recursively reload itself** (Because the logoutUrl lives inside a already created meeting on the BBB-Server, you need to keep the .html file. The JSP will only be called for new created bbb-meetings. Used the default Strings in en.)
**added messages to ToolMessages.properties for autoclosing**
**changed redirect from BBB to the jsp file**